### PR TITLE
Add auxheat status

### DIFF
--- a/custom_components/mbapi2020/client.py
+++ b/custom_components/mbapi2020/client.py
@@ -218,6 +218,9 @@ class Client: # pylint: disable-too-few-public-methods
         car.electric = self._get_car_values(
             c, car.finorvin, Electric() if not car.electric else car.electric, ELECTRIC_OPTIONS, update_mode)
 
+        car.auxheat = self._get_car_values(
+            c, car.finorvin, Auxheat() if not car.auxheat else car.auxheat, AUX_HEAT_OPTIONS, update_mode)
+
         # _LOGGER.debug("_get_cars - Feature Check: aux_heat:%s ", {car.features.aux_heat})
         # if car.features.aux_heat:
         #     car.auxheat = self._get_car_values(


### PR DESCRIPTION
Everything was already in place, except the auxheat options weren't actually loaded.
Works on my car which has auxheat built-in. Probably should be tested against a car that doesn't have auxheat.

Disclosure: I am employed by Mercedes-Benz AG. But while I am affiliated with Mercedes-Benz, I make this contribution as a private individual, not in my professional capacity. This contribution is in no way related to my employment with Mercedes-Benz AG and/or endorsed by Mercedes-Benz AG.