### PR TITLE
Add unique identifier to token path

### DIFF
--- a/custom_components/mbapi2020/client.py
+++ b/custom_components/mbapi2020/client.py
@@ -69,7 +69,7 @@ class Client:  # pylint: disable-too-few-public-methods
         session: Optional[ClientSession] = None,
         hass: Optional[HomeAssistant] = None,
         config_entry=None,
-        cache_path: Optional[str] = None,
+        unique_id: Optional[str] = None,
         region: str = None,
     ) -> None:
         self._ws_reconnect_delay = DEFAULT_SOCKET_MIN_RETRY
@@ -83,17 +83,23 @@ class Client:  # pylint: disable-too-few-public-methods
         self.config_entry = config_entry
         self._locale: str = DEFAULT_LOCALE
         self._country_code: str = DEFAULT_COUNTRY_CODE
+        self._cache_path: str = self._hass.config.path(DEFAULT_CACHE_PATH)
+        self._unique_id: str = unique_id
 
         if self.config_entry:
+            self._unique_id = self._unique_id or self.config_entry.unique_id
             if self.config_entry.options:
                 self._country_code = self.config_entry.options.get(CONF_COUNTRY_CODE, DEFAULT_COUNTRY_CODE)
                 self._locale = self.config_entry.options.get(CONF_LOCALE, DEFAULT_LOCALE)
+
+        if self._unique_id:
+            self._cache_path = f"{self._hass.config.path(DEFAULT_TOKEN_PATH)}.{self._unique_id}"
 
         self.oauth: Oauth = Oauth(
             session=session,
             locale=self._locale,
             country_code=self._country_code,
-            cache_path=self._hass.config.path(DEFAULT_TOKEN_PATH),
+            cache_path=self._cache_path,
             region=self._region,
         )
         self.api: API = API(session=session, oauth=self.oauth, region=self._region)

--- a/custom_components/mbapi2020/config_flow.py
+++ b/custom_components/mbapi2020/config_flow.py
@@ -65,7 +65,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             nonce = str(uuid.uuid4())
             user_input["nonce"] = nonce
 
-            client = Client(session=session, hass=self.hass, region=user_input[CONF_REGION])
+            client = Client(session=session, hass=self.hass, region=user_input[CONF_REGION], unique_id=self.unique_id)
             try:
                 await client.oauth.request_pin(user_input[CONF_USERNAME], nonce)
             except MbapiError as error:
@@ -90,7 +90,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             nonce = self.data["nonce"]
             session = aiohttp_client.async_get_clientsession(self.hass, VERIFY_SSL)
 
-            client = Client(session=session, hass=self.hass, region=self.data[CONF_REGION])
+            client = Client(session=session, hass=self.hass, region=self.data[CONF_REGION], unique_id=self.unique_id)
             try:
                 result = await client.oauth.request_access_token(self.data[CONF_USERNAME], pin, nonce)
             except MbapiError as error:
@@ -137,7 +137,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
 
         if user_input is not None:
             if user_input[CONF_DELETE_AUTH_FILE] == True:
-                auth_file = f"{self.hass.config.config_dir}/{DEFAULT_TOKEN_PATH}"
+                auth_file = f"{self.hass.config.config_dir}/{DEFAULT_TOKEN_PATH}.{self.config_entry.unique_id}"
                 LOGGER.warning("DELETE Auth File requested %s", auth_file)
                 if os.path.isfile(auth_file):
                     os.remove(auth_file)


### PR DESCRIPTION
This allows for adding the mbapi2020 integration more than once with different usernames. Without this the token cache is reused by all instances resulting in only one instance working.