### PR TITLE
change state class of odometer to total_increasing

### DIFF
--- a/custom_components/mbapi2020/const.py
+++ b/custom_components/mbapi2020/const.py
@@ -748,7 +748,7 @@ SENSORS = {
         SensorDeviceClass.DISTANCE,
         False,
         None,
-        SensorStateClass.MEASUREMENT,
+        SensorStateClass.TOTAL_INCREASING,
         None,
     ],
     "averageSpeedStart": [


### PR DESCRIPTION
odometer is not a measurement value but a total increasing, which makes it possible to use this in statistics-graph in frontend