### PR TITLE
remove tirepressure attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,14 @@ Depends on your own car or purchased Mercedes Benz licenses.
     tireTemperatureRearRight, tireTemperatureFrontLeft
     ```
 
+* tirepressureRearLeft
+
+* tirepressureRearRight
+
+* tirepressureFrontRight
+
+* tirepressureFrontLeft
+
 * windowsClosed
   
   ```

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Depends on your own car or purchased Mercedes Benz licenses.
 
     ```
     attributes: 
-    tirepressureRearLeft, tirepressureRearRight, tirepressureFrontRight, tirepressureFrontLeft, tireMarkerFrontRight, tireMarkerFrontLeft,tireMarkerRearLeft, tireMarkerRearRight, tirewarningsrdk, tirewarningsprw, tireTemperatureRearLeft, tireTemperatureFrontRight,
+    tireMarkerFrontRight, tireMarkerFrontLeft,tireMarkerRearLeft, tireMarkerRearRight, tirewarningsrdk, tirewarningsprw, tireTemperatureRearLeft, tireTemperatureFrontRight,
     tireTemperatureRearRight, tireTemperatureFrontLeft
     ```
 

--- a/custom_components/mbapi2020/const.py
+++ b/custom_components/mbapi2020/const.py
@@ -366,10 +366,6 @@ BinarySensors = {
         "value",
         None,
         {
-            "tirepressureRearLeft",
-            "tirepressureRearRight",
-            "tirepressureFrontRight",
-            "tirepressureFrontLeft",
             "tireMarkerFrontRight",
             "tireMarkerFrontLeft",
             "tireMarkerRearLeft",


### PR DESCRIPTION
Like discussed [here](https://github.com/ReneNulschDE/mbapi2020/pull/137#issuecomment-1699079216), the tire pressure attributes can be removed, as the users had enough time to migrate.