### PR TITLE
Add new sensor "Wiper Health"

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,13 @@ Depends on your own car or purchased Mercedes Benz licenses.
   precondState, precondActive, precondError, precondNow, precondNowError, precondDuration, precondatdeparture, precondAtDepartureDisable, precondSeatFrontLeft, precondSeatFrontRight, precondSeatRearLeft, precondSeatRearRight
   ```
 
+- wiperHealth
+
+  ```
+  attributes:
+  wiperLifetimeExceeded [EXPERIMENTAL, user feedback wanted]
+  ```
+
 ### Device Tracker
 
 ```

--- a/custom_components/mbapi2020/car.py
+++ b/custom_components/mbapi2020/car.py
@@ -157,6 +157,8 @@ AUX_HEAT_OPTIONS = [
     "auxheattime3",
 ]
 
+WIPER_OPTIONS = ["wiperLifetimeExceeded", "wiperHealthPercent"]
+
 PRE_COND_OPTIONS = [
     "precondStatus",
     "precondOperatingMode",
@@ -224,6 +226,7 @@ class Car:
 
         self.binarysensors = None
         self.tires = None
+        self.wipers = None
         self.odometer = None
         self.doors = None
         self.location = None
@@ -295,6 +298,11 @@ class Tires:
 
     name: str = "Tires"
 
+@dataclass(init=False)
+class Wipers:
+    """Stores the Wiper values at runtime."""
+
+    name: str = "Wipers"
 
 @dataclass(init=False)
 class Odometer:

--- a/custom_components/mbapi2020/client.py
+++ b/custom_components/mbapi2020/client.py
@@ -30,6 +30,7 @@ from .car import (
     PRE_COND_OPTIONS,
     TIRE_OPTIONS,
     WINDOW_OPTIONS,
+    WIPER_OPTIONS,
     Auxheat,
     BinarySensors,
     Car,
@@ -44,6 +45,7 @@ from .car import (
     Precond,
     Tires,
     Windows,
+    Wipers,
 )
 from .const import (
     CONF_DEBUG_FILE_SAVE,
@@ -300,6 +302,14 @@ class Client:  # pylint: disable-too-few-public-methods
             car.finorvin,
             Tires() if not car.tires else car.tires,
             TIRE_OPTIONS,
+            update_mode,
+        )
+
+        car.wipers = self._get_car_values(
+            received_car_data,
+            car.finorvin,
+            Wipers() if not car.wipers else car.wipers,
+            WIPER_OPTIONS,
             update_mode,
         )
 

--- a/custom_components/mbapi2020/const.py
+++ b/custom_components/mbapi2020/const.py
@@ -1267,6 +1267,23 @@ SENSORS = {
         None,
         None,
     ],
+    "wiperHealthPercent": [
+        "Wiper Health",
+        None,  # Deprecated: DO NOT USE
+        "wipers",
+        "wiperHealthPercent",
+        "value",
+        None,
+        {
+            "wiperLifetimeExceeded",
+        },
+        "mdi:wiper",
+        None,
+        False,
+        None,
+        None,
+        None,
+    ],
 }
 
 LOCKS = {


### PR DESCRIPTION
This pull request adds a new sensor called "Wiper Health" that indicates the condition of the windshield wipers as a percentage. Additionally, the attribute wiperLifetimeExceeded is included. However, in my experience, it provides implausible results. As a result, I've marked this field as experimental in the documentation.