### PR TITLE
Remove Sensitive Information from Debug Report

### DIFF
--- a/custom_components/mbapi2020/const.py
+++ b/custom_components/mbapi2020/const.py
@@ -78,6 +78,9 @@ JSON_EXPORT_IGNORED_KEYS = (
     "licensePlate",
     "vin",
     "dealers",
+    "positionLong",
+    "positionLat",
+    "positionHeading",
 )
 
 

--- a/custom_components/mbapi2020/const.py
+++ b/custom_components/mbapi2020/const.py
@@ -80,7 +80,6 @@ JSON_EXPORT_IGNORED_KEYS = (
     "dealers",
     "positionLong",
     "positionLat",
-    "positionHeading",
 )
 
 

--- a/custom_components/mbapi2020/const.py
+++ b/custom_components/mbapi2020/const.py
@@ -79,7 +79,6 @@ JSON_EXPORT_IGNORED_KEYS = (
     "vin",
     "dealers",
     "positionLong",
-    "positionLat",
 )
 
 


### PR DESCRIPTION
This PR removes sensitive information from the debug report, focusing on the following fields:

- positionLong
- positionLat
- positionHeading

These fields are now sanitized from the debug reports to ensure that no sensitive location data is exposed.