### PR TITLE
Add german translation for switch entities

### DIFF
--- a/custom_components/mbapi2020/translations/de.json
+++ b/custom_components/mbapi2020/translations/de.json
@@ -47,5 +47,15 @@
                 }
             }
         }
+    },
+    "entity": {
+        "switch": {
+            "auxheat": {
+                "name": "Standheizung"
+            },
+            "precond": {
+                "name": "Vorklimatisierung"
+            }
+        }
     }
 }


### PR DESCRIPTION
Translations seem to be working now for entities created via EntityDescription. I've included the German translations for the switch entities.