### PR TITLE
fix: avoid several decimal cases on chargingpowerkw

### DIFF
--- a/custom_components/mbapi2020/sensor.py
+++ b/custom_components/mbapi2020/sensor.py
@@ -116,6 +116,9 @@ class MercedesMESensor(MercedesMeEntity, RestoreSensor):
         if self._internal_name == "lastParkEvent":
             if self._state:
                 return datetime.fromtimestamp(int(self._state))
+        elif self._internal_name == "chargingpowerkw":
+            if self._state:
+                return round(float(self._state), 1)
 
         return self._state
 

--- a/custom_components/mbapi2020/sensor.py
+++ b/custom_components/mbapi2020/sensor.py
@@ -117,7 +117,7 @@ class MercedesMESensor(MercedesMeEntity, RestoreSensor):
             if self._state:
                 return datetime.fromtimestamp(int(self._state))
         elif self._internal_name == "chargingpowerkw":
-            if self._state:
+            if self._state and isinstance(self._state, (int, float)):
                 return round(float(self._state), 1)
 
         return self._state


### PR DESCRIPTION
Hey,

first of all thanks for the project, really nice!

In this PR I intend to avoid having several decimal cases on `chargingpowerkw`.

When charging an electric vehicle I was getting as value `1,599999999999` kw as the sensor value. By rounding it to one decimal case, this fixes the issue and gets consistent with what is presented in MB application.