### PR TITLE
Fix CancelledError suppression bug in cleanup task

### DIFF
--- a/custom_components/mbapi2020/websocket.py
+++ b/custom_components/mbapi2020/websocket.py
@@ -636,7 +636,7 @@ class Websocket:
                 self._LOGGER.warning("websocket task didn't finish in time, cancelling")
                 if self._websocket_task:
                     self._websocket_task.cancel()
-                with contextlib.suppress(Exception):
+                with contextlib.suppress(Exception, asyncio.CancelledError):
                     await self._websocket_task
             except asyncio.CancelledError:
                 # Beim Shutdown ignorieren
@@ -648,7 +648,7 @@ class Websocket:
                 await asyncio.shield(asyncio.wait_for(self._queue_task, timeout=2.0))
             except asyncio.TimeoutError:
                 self._queue_task.cancel()
-                with contextlib.suppress(Exception):
+                with contextlib.suppress(Exception, asyncio.CancelledError):
                     await self._queue_task
             except asyncio.CancelledError:
                 pass


### PR DESCRIPTION
This PR fixes a bug where `asyncio.CancelledError` was not caught by `contextlib.suppress(Exception)` since Python 3.8, which caused background reconnects and cleanups to crash unexpectedly.


```python
with contextlib.suppress(Exception):
    await self._websocket_task

```

Since Python 3.8, asyncio.CancelledError inherits from BaseException rather than Exception. Therefore, suppress(Exception) fails to catch it. If the websocket task is cancelled (which happens during forced reconnects or shutdown when the task takes longer than 2.0s to exit), the unhandled CancelledError crashes the entire cleanup sequence. This leaves zombie tasks running in the background and can interrupt proper resource cleanup.