### PR TITLE
fix: Report unlocked state instead of unknown after unlock

### DIFF
--- a/custom_components/mbapi2020/lock.py
+++ b/custom_components/mbapi2020/lock.py
@@ -109,10 +109,18 @@ class MercedesMELock(MercedesMeEntity, LockEntity, RestoreEntity):
         """Return true if device is locked."""
 
         value = self._get_car_value(self._feature_name, self._object_name, self._attrib_name, None)
-        if value and int(value) in (1, 2):
+        if value is None:
+            return None
+
+        try:
+            status = int(value)
+        except (TypeError, ValueError):
+            return None
+
+        if status in (1, 2):
             return True
 
-        if value and int(value) in (0, 3):
+        if status in (0, 3):
             return False
 
         return None


### PR DESCRIPTION
## Summary

After unlocking the car, the lock entity showed **unknown/unavailable** instead of *unlocked*.

Root cause: the new `vehicle_status_updates` path (`vsu_helper.py`) maps `DOORLOCKSTATUSVEHICLE_UNLOCKED` to the integer `0` via `VSU_ENUM_VALUE_TO_INT`. The `is_locked` property in `lock.py` used a truthiness check (`if value and int(value) in (0, 3)`), so `0` was treated as missing data and the property returned `None`. The legacy VEP path delivered the string `"0"` (truthy), which is why this only surfaced with VSU messages.

## Changes

- `is_locked` now checks `value is None` explicitly instead of relying on truthiness
- Non-numeric values (e.g. `"error"`) return `None` instead of raising `ValueError`

## Testing

- `python3 -m py_compile` passes
- Logic table verified: `0`/`"0"` return unlocked, `1`/`2` locked, `3`/`"3"` unlocked, `None`/`"error"`/`4` return unknown