### PR TITLE
fix: restore preclimate status handling for VSU payloads

### DIFF
--- a/custom_components/mbapi2020/client.py
+++ b/custom_components/mbapi2020/client.py
@@ -884,27 +884,68 @@ class Client:
     def _get_car_values_handle_precond_status(self, car_detail, class_instance, option, update, vin: str):
         attributes = car_detail.get("attributes", {})
 
+        def _attr_to_bool(attr: dict[str, Any]) -> bool:
+            """Coerce legacy/VSU attribute payloads to a boolean state."""
+            if not attr:
+                return False
+
+            if "bool_value" in attr:
+                return bool(attr.get("bool_value"))
+
+            raw_value = attr.get("value")
+            if isinstance(raw_value, bool):
+                return raw_value
+            if isinstance(raw_value, int):
+                return raw_value > 0
+            if isinstance(raw_value, str):
+                lowered = raw_value.lower()
+                if lowered in ("true", "false"):
+                    return lowered == "true"
+                if raw_value.lstrip("-").isdigit():
+                    return int(raw_value) > 0
+
+            raw_int = attr.get("int_value")
+            if raw_int is not None:
+                try:
+                    return int(raw_int) > 0
+                except (TypeError, ValueError):
+                    return False
+
+            return False
+
         # Retrieve attributes with defaults to handle missing keys
         precond_now_attr = attributes.get("precondNow", {})
         precond_active_attr = attributes.get("precondActive", {})
         precond_operating_mode_attr = attributes.get("precondOperatingMode", {})
+        precond_state_attr = attributes.get("precondState", {})
+        precond_state_value = precond_state_attr.get("value", {}) if isinstance(precond_state_attr, dict) else {}
 
-        # Extract values and convert to boolean where necessary
-        precond_now_value = precond_now_attr.get("bool_value", False)
-        precond_active_value = precond_active_attr.get("bool_value", False)
+        # VSU reports precondNow as an enum attribute and precondState as a
+        # nested message, while the legacy VEP path used plain booleans.
+        precond_now_value = _attr_to_bool(precond_now_attr)
+        precond_active_value = _attr_to_bool(precond_active_attr)
         precond_operating_mode_value = precond_operating_mode_attr.get("int_value", 0)
         precond_operating_mode_bool = int(precond_operating_mode_value) > 0
+        precond_state_activation_value = False
+        if isinstance(precond_state_value, dict):
+            precond_state_activation_value = bool(precond_state_value.get("activation_state", False))
 
         # Calculate precondStatus
-        value = precond_now_value or precond_active_value or precond_operating_mode_bool
+        value = (
+            precond_now_value
+            or precond_active_value
+            or precond_operating_mode_bool
+            or precond_state_activation_value
+        )
 
         # Determine if any of the attributes are present
-        if precond_now_attr or precond_active_attr or precond_operating_mode_attr:
+        if precond_now_attr or precond_active_attr or precond_operating_mode_attr or precond_state_attr:
             status = "VALID"
             time_stamp = max(
                 int(precond_now_attr.get("timestamp", 0)),
                 int(precond_active_attr.get("timestamp", 0)),
                 int(precond_operating_mode_attr.get("timestamp", 0)),
+                int(precond_state_attr.get("timestamp", 0)),
             )
             return CarAttribute(
                 value=value,

--- a/custom_components/mbapi2020/client.py
+++ b/custom_components/mbapi2020/client.py
@@ -11,6 +11,7 @@ from pathlib import Path
 import threading
 import time
 import traceback
+from typing import Any
 import uuid
 
 from aiohttp import ClientSession
@@ -932,10 +933,7 @@ class Client:
 
         # Calculate precondStatus
         value = (
-            precond_now_value
-            or precond_active_value
-            or precond_operating_mode_bool
-            or precond_state_activation_value
+            precond_now_value or precond_active_value or precond_operating_mode_bool or precond_state_activation_value
         )
 
         # Determine if any of the attributes are present

--- a/custom_components/mbapi2020/vsu_helper.py
+++ b/custom_components/mbapi2020/vsu_helper.py
@@ -68,6 +68,16 @@ _VSU_STATUS_TO_LEGACY: dict[str, str | int] = {
     "VALUE_NOT_AVAILABLE": 4,
 }
 
+# Some VSU attributes are enum/bool protobuf fields whose default value is
+# omitted by MessageToJson (proto3 semantics). Preserve the legacy behaviour by
+# synthesizing an explicit inactive/off value when the attribute is present with
+# metadata but without a JSON ``value`` field.
+_VSU_DEFAULT_OMITTED_VALUES: dict[str, bool | int] = {
+    "precondNow": 0,
+    "precondActive": False,
+    "precondOperatingMode": 0,
+}
+
 
 def _snake_to_camel(name: str) -> str:
     """Convert snake_case to camelCase.
@@ -207,7 +217,11 @@ def _normalize_attribute(key: str, vsu_attr: dict[str, Any]) -> tuple[str, dict[
     if display_value is not None:
         legacy["display_value"] = display_value
 
-    _normalize_value(legacy_key, vsu_attr.get("value"), legacy)
+    raw_value = vsu_attr.get("value")
+    if raw_value is None and metadata and legacy_key in _VSU_DEFAULT_OMITTED_VALUES:
+        raw_value = _VSU_DEFAULT_OMITTED_VALUES[legacy_key]
+
+    _normalize_value(legacy_key, raw_value, legacy)
 
     return legacy_key, legacy
 


### PR DESCRIPTION
## Summary

Restore "Preclimate Status" handling for the "vehicle_status_updates" data path introduced in v0.38.
fixes https://github.com/ReneNulschDE/mbapi2020/issues/424 

## Problem

`PRECONDSTART` / `PRECONDSTOP` commands complete successfully, but the `Preclimate Status` entity remains `off`.

The regression comes from the VSU compatibility path:
- `precondNow` is reported as an enum-style attribute in VSU, not a plain boolean
- `precondState.activation_state` can also carry the active-state signal
- proto3 default-valued fields can be omitted from the JSON payload entirely
- the legacy handler only evaluated `bool_value` for `precondNow` / `precondActive`

## Fix

Update the precondition status handling to:
- coerce legacy and VSU attribute payloads to booleans
- accept enum/int/string representations for `precondNow`
- consider `precondState.value.activation_state`
- treat `precondState` as a valid timestamp/source for the synthesized status

Update the VSU compatibility layer to:
- synthesize explicit inactive defaults for preconditioning fields when proto3 omits default JSON values
- preserve the legacy attribute surface expected by existing handlers

## Validation

- `python -m py_compile custom_components/mbapi2020/client.py custom_components/mbapi2020/vsu_helper.py`
- normalization behavior was checked against captured VSU payloads and synthetic active-state payloads
- tested in my environment with my EQB


