### PR TITLE
fix: correct window cover position mapping for windowStatusOverall

### DIFF
--- a/custom_components/mbapi2020/cover.py
+++ b/custom_components/mbapi2020/cover.py
@@ -25,12 +25,17 @@ from .const import CONF_FT_DISABLE_CAPABILITY_CHECK, DOMAIN, LOGGER, STATE_CONFI
 from .coordinator import MBAPI2020DataUpdateCoordinator
 from .helper import LogHelper as loghelper
 
-WINDOW_STATUS_CLOSED = {"2", 2}
-WINDOW_STATUS_OPEN = {"1", 1}
-WINDOW_STATUS_VENTILATING = {"3", 3}
-WINDOW_STATUS_INTERMEDIATE = {"0", 0, "4", 4}
-WINDOW_STATUS_OVERALL_CLOSED = {"0", 0, "CLOSED", "closed"}
-WINDOW_STATUS_OVERALL_OPEN = {"OPEN", "open"}
+# Positions for the individual windows, based on the proto enum Windowstatus:
+# 0 INTERMEDIATE, 1 COMPLETELY_OPENED, 2 COMPLETELY_CLOSED, 3 AIRING_POSITION
+WINDOW_STATUS_POSITIONS: dict[int, int] = {0: 50, 1: 100, 2: 0, 3: 10}
+
+# Positions for the window summary, based on the proto enum WindowStatusOverall:
+# 0 OPEN, 1 CLOSED, 2 COMPLETELY_OPEN, 3 AIRING
+# Note the numbering differs from the individual windows above
+WINDOW_STATUS_OVERALL_POSITIONS: dict[int, int] = {0: 50, 1: 0, 2: 100, 3: 10}
+
+# Retrieval status values that indicate the car did not report a usable value
+WINDOW_STATUS_INVALID_RETRIEVAL_STATUS = {3, "3", 4, "4", "NOT_RECEIVED", "error"}
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -117,27 +122,27 @@ WINDOW_COVER_DESCRIPTIONS: list[MercedesMeCoverEntityDescription] = [
 
 
 def _status_to_position(status: Any, *, overall: bool = False) -> int | None:
-    if overall:
-        if isinstance(status, bool):
-            return 0 if status else 100
-        if status in WINDOW_STATUS_OVERALL_CLOSED:
-            return 0
-        if status in WINDOW_STATUS_OVERALL_OPEN:
-            return 100
-        try:
-            return 100 if int(status) > 0 else 0
-        except (TypeError, ValueError):
-            return None
+    """Translate a reported window status into a cover position."""
+    if status is None:
+        return None
 
-    if status in WINDOW_STATUS_CLOSED:
-        return 0
-    if status in WINDOW_STATUS_OPEN:
-        return 100
-    if status in WINDOW_STATUS_VENTILATING:
-        return 10
-    if status in WINDOW_STATUS_INTERMEDIATE:
-        return 50
-    return None
+    # The REST fallback builds a synthetic windowStatusOverall where True means
+    # that all windows are closed
+    if isinstance(status, bool):
+        return 0 if status else 100
+
+    if isinstance(status, str):
+        normalized = status.strip().upper()
+        if normalized == "CLOSED":
+            return 0
+        if normalized == "OPEN":
+            return 100
+
+    positions = WINDOW_STATUS_OVERALL_POSITIONS if overall else WINDOW_STATUS_POSITIONS
+    try:
+        return positions.get(int(status))
+    except (TypeError, ValueError):
+        return None
 
 
 class MercedesMeCover(MercedesMeEntity, CoverEntity):
@@ -157,11 +162,15 @@ class MercedesMeCover(MercedesMeEntity, CoverEntity):
     def supported_features(self) -> CoverEntityFeature:
         """Return the supported features."""
         features = CoverEntityFeature(0)
-        supports_variable_window = self._skip_capability_check or self._car.features.get("variableOpenableWindow") is True
+        supports_variable_window = (
+            self._skip_capability_check or self._car.features.get("variableOpenableWindow") is True
+        )
 
         if self.entity_description.key == "windows":
             if (
-                self._skip_capability_check or self._car.features.get("WINDOWS_OPEN") is True or supports_variable_window
+                self._skip_capability_check
+                or self._car.features.get("WINDOWS_OPEN") is True
+                or supports_variable_window
             ):
                 features |= CoverEntityFeature.OPEN
             if (
@@ -217,7 +226,12 @@ class MercedesMeCover(MercedesMeEntity, CoverEntity):
 
     @property
     def _window_status(self) -> Any:
-        return self._get_car_value("windows", self.entity_description.status_attribute, "value", None)
+        status_attribute = self.entity_description.status_attribute
+        retrieval_status = self._get_car_value("windows", status_attribute, "retrievalstatus", "error")
+        if retrieval_status in WINDOW_STATUS_INVALID_RETRIEVAL_STATUS:
+            return None
+
+        return self._get_car_value("windows", status_attribute, "value", None)
 
     @property
     def _is_overall_cover(self) -> bool:


### PR DESCRIPTION
Fixes #426

## Problem

The summary `windows` cover reported the inverted state: with all windows closed it showed **100% open**, and after opening a single window it showed **closed**.

## Cause

`windowStatusOverall` uses the `WindowStatusOverall` proto enum, which is numbered differently from the `Windowstatus` enum used by the individual windows:

| value | `Windowstatus` (single window) | `WindowStatusOverall` (summary) |
|---|---|---|
| 0 | INTERMEDIATE | **OPEN** |
| 1 | COMPLETELY_OPENED | **CLOSED** |
| 2 | COMPLETELY_CLOSED | COMPLETELY_OPEN |
| 3 | AIRING_POSITION | AIRING |

`_status_to_position()` treated the overall value as "0 = closed, anything > 0 = open":

```python
if status in WINDOW_STATUS_OVERALL_CLOSED:   # {"0", 0, "CLOSED", "closed"}
    return 0
...
return 100 if int(status) > 0 else 0
```

So `1` (CLOSED) fell into the `int(status) > 0` branch and became 100%, while `0` (OPEN) matched the "closed" set. Exactly inverted.

Confirmed by the diagnostics attached to the issue: all four individual windows report `value: 2` (COMPLETELY_CLOSED) while `windowStatusOverall` reports `value: 1` (CLOSED) — displayed as 100% open.

## Changes

- Replace the status sets with two explicit, enum-accurate position maps (`WINDOW_STATUS_POSITIONS`, `WINDOW_STATUS_OVERALL_POSITIONS`), with a comment about the differing numbering.
- Rewrite `_status_to_position()`: bool branch first (the synthetic REST value, where `True` means all windows closed), then `OPEN`/`CLOSED` string tolerance, then the enum lookup. Unknown values now return `None` instead of a wrong position.
- `_window_status` now ignores attributes whose `retrievalstatus` is 3/4/`NOT_RECEIVED`/`error`. Previously a missing attribute yielded `value=0`, which rendered as INTERMEDIATE/50% — a second route to a wrong reading on cars that do not report all four windows.

## Data paths verified

- **VEP/push**: delivers the enum ints directly (diagnostics from the issue).
- **VSU/push**: `vsu_enums.py` maps `WINDOW_STATUS_OVERALL_CLOSED -> 1` etc. to the same ints, so it was affected identically and is fixed by the same change. Cross-checked against recorded `vsu*.json` samples, where `windowstatusfrontleft = WINDOWSTATUS_COMPLETELY_OPENED` correlates with `window_status_overall = WINDOW_STATUS_OVERALL_COMPLETELY_OPEN`.
- **REST/pull**: `_create_synthetic_window_status_overall()` produces a `bool_value` (`True` = closed). That path was already correct and stays correct.

The `Windows Closed` binary sensor was never affected — it evaluates `1` as truthy = closed.

## Testing

All eight enum values plus the bool/string/`None` cases were checked against the new mapping. `ruff format` and `ruff check` pass (the formatting run also wrapped two pre-existing lines over 120 characters in `supported_features`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)