### PR TITLE
chore: bump manifest version to 0.40.0

### DIFF
--- a/custom_components/mbapi2020/manifest.json
+++ b/custom_components/mbapi2020/manifest.json
@@ -10,5 +10,5 @@
   "issue_tracker": "https://github.com/ReneNulschDE/mbapi2020/issues",
   "loggers": ["custom_components.mbapi2020"],
   "requirements": ["protobuf>=3.19.5"],
-  "version": "0.39.0"
+  "version": "0.40.0"
 }


### PR DESCRIPTION
Marks `master` as a development version so dev installs are recognizable in diagnostics. The released version string is set from the tag by the release pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)