### PR TITLE
fix: prevent duplicate platform setup from the dataload fallback timer

### DIFF
--- a/custom_components/mbapi2020/client.py
+++ b/custom_components/mbapi2020/client.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 import datetime as dt
 from datetime import datetime, timezone
 import json
@@ -22,9 +21,10 @@ from custom_components.mbapi2020.proto import client_pb2
 import custom_components.mbapi2020.proto.vehicle_commands_pb2 as pb2_commands
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import STATE_UNKNOWN
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import system_info
+from homeassistant.helpers.event import async_call_later
 
 from .car import (
     AUX_HEAT_OPTIONS,
@@ -73,6 +73,9 @@ LOGGER = logging.getLogger(__name__)
 DEBUG_SIMULATE_PARTIAL_UPDATES_ONLY = False
 GEOFENCING_MAX_RETRIES = 1
 
+# Fallback delay: create the entities even if not every car reported a full data set
+DATALOAD_COMPLETE_FALLBACK_DELAY = 30
+
 
 class Client:
     """define the client."""
@@ -95,6 +98,7 @@ class Client:
         self._region = region
         self._on_dataload_complete = None
         self._dataload_complete_fired = False
+        self._dataload_fallback_handle = None
         self._coordinator_ref = None
         self._disable_rlock = False
         self.__lock = None
@@ -1110,9 +1114,7 @@ class Client:
         if not self._first_vepupdates_processed:
             self._vepupdates_time_first_message = datetime.now()
             self._first_vepupdates_processed = True
-            self._hass.loop.call_later(
-                30, lambda: self._hass.async_add_executor_job(self._safe_create_on_dataload_complete_task)
-            )
+            self._arm_dataload_complete_fallback()
 
         self._build_car(vep_json, update_mode=False)
         if self._dataload_complete_fired:
@@ -1137,6 +1139,7 @@ class Client:
                 LOGGER.debug("_process_vep_updates - all completed - fire event: _on_dataload_complete")
                 self._hass.async_create_task(self._on_dataload_complete())
                 self._dataload_complete_fired = True
+                self._cancel_dataload_complete_fallback()
 
     def _process_vep_updates(self, data):
         LOGGER.debug("Start _process_vep_updates")
@@ -1150,9 +1153,7 @@ class Client:
         if not self._first_vepupdates_processed:
             self._vepupdates_time_first_message = datetime.now()
             self._first_vepupdates_processed = True
-            self._hass.loop.call_later(
-                30, lambda: self._hass.async_add_executor_job(self._safe_create_on_dataload_complete_task)
-            )
+            self._arm_dataload_complete_fallback()
 
         for vin in cars:
             if vin in self.excluded_cars:
@@ -1209,6 +1210,7 @@ class Client:
                 LOGGER.debug("_process_vep_updates - all completed - fire event: _on_dataload_complete")
                 self._hass.async_create_task(self._on_dataload_complete())
                 self._dataload_complete_fired = True
+                self._cancel_dataload_complete_fallback()
 
     def _process_vehicle_status_updates(self, data):
         LOGGER.debug("Start _process_vehicle_status_updates")
@@ -1221,9 +1223,7 @@ class Client:
         if not self._first_vepupdates_processed:
             self._vepupdates_time_first_message = datetime.now()
             self._first_vepupdates_processed = True
-            self._hass.loop.call_later(
-                30, lambda: self._hass.async_add_executor_job(self._safe_create_on_dataload_complete_task)
-            )
+            self._arm_dataload_complete_fallback()
 
         for vin, vsu_car in cars.items():
             if vin in self.excluded_cars:
@@ -1278,6 +1278,7 @@ class Client:
                 LOGGER.debug("_process_vehicle_status_updates - all completed - fire event: _on_dataload_complete")
                 self._hass.async_create_task(self._on_dataload_complete())
                 self._dataload_complete_fired = True
+                self._cancel_dataload_complete_fallback()
 
     def _process_assigned_vehicles(self, data):
         if not self._dataload_complete_fired:
@@ -2382,7 +2383,33 @@ class Client:
                     car.has_geofencing = False
                 car.geo_fencing_retry_counter = car.geo_fencing_retry_counter + 1
 
-    def _safe_create_on_dataload_complete_task(self):
-        """Create task in a thread-safe way."""
-        # Zurück zum Event Loop
-        asyncio.run_coroutine_threadsafe(self._on_dataload_complete(), self._hass.loop)
+    @callback
+    def _arm_dataload_complete_fallback(self) -> None:
+        """Start the fallback timer for the entity creation."""
+        if self._dataload_fallback_handle is not None:
+            return
+
+        self._dataload_fallback_handle = async_call_later(
+            self._hass, DATALOAD_COMPLETE_FALLBACK_DELAY, self._async_dataload_complete_fallback
+        )
+
+    @callback
+    def _cancel_dataload_complete_fallback(self) -> None:
+        """Cancel the fallback timer for the entity creation."""
+        if self._dataload_fallback_handle is not None:
+            self._dataload_fallback_handle()
+            self._dataload_fallback_handle = None
+
+    @callback
+    def _async_dataload_complete_fallback(self, _now) -> None:
+        """Create the entities when not every car reported a full data set in time."""
+        self._dataload_fallback_handle = None
+
+        if self._dataload_complete_fired:
+            return
+
+        LOGGER.debug(
+            "Dataload fallback after %s seconds - fire event: _on_dataload_complete", DATALOAD_COMPLETE_FALLBACK_DELAY
+        )
+        self._dataload_complete_fired = True
+        self._hass.async_create_task(self._on_dataload_complete())

--- a/custom_components/mbapi2020/coordinator.py
+++ b/custom_components/mbapi2020/coordinator.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from typing import Any
 
@@ -37,6 +38,7 @@ class MBAPI2020DataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self.config_entry: ConfigEntry = config_entry
         self.initialized: bool = False
         self.entry_setup_complete: bool = False
+        self._entry_setup_lock = asyncio.Lock()
         session = async_get_clientsession(hass, VERIFY_SSL)
 
         # Find the right way to migrate old configs
@@ -63,15 +65,22 @@ class MBAPI2020DataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
         return {}  # self.client.cars
 
-    @callback
     async def on_dataload_complete(self):
-        """Create sensors after the web_socket initial data is complete."""
-        if not self.entry_setup_complete:
-            LOGGER.info("Car Load complete - start sensor creation")
-            await self.hass.config_entries.async_forward_entry_setups(self.config_entry, MERCEDESME_COMPONENTS)
+        """Create sensors after the web_socket initial data is complete.
 
-        self.entry_setup_complete = True
-        self.client._dataload_complete_fired = True
+        The lock is required because this can be called concurrently from the
+        regular completion path and from the fallback timer in the client.
+        Home Assistant does not guard against forwarding an entry twice while
+        the entry setup is still in progress, so a second call would raise
+        "Config entry ... has already been setup!" for every platform.
+        """
+        async with self._entry_setup_lock:
+            if not self.entry_setup_complete:
+                LOGGER.info("Car Load complete - start sensor creation")
+                await self.hass.config_entries.async_forward_entry_setups(self.config_entry, MERCEDESME_COMPONENTS)
+                self.entry_setup_complete = True
+
+            self.client._dataload_complete_fired = True
 
     async def ws_connect(self):
         """Register handlers and connect to the websocket."""


### PR DESCRIPTION
Fixes #429

Thanks to @0xmachos for the report — the analysis was accurate and every cited line checked out.

## Problem

On some restarts, setup for every platform raised `ValueError: Config entry ... for mbapi2020.<platform> has already been setup!`.

`on_dataload_complete()` was an unlocked check-then-act across an `await`: it checked `entry_setup_complete`, awaited `async_forward_entry_setups()`, and only set the flag *afterwards*. A second invocation arriving while the first forward was still in flight saw the flag as `False` and forwarded the same entry again.

The second invocation came from the 30 second fallback timer. `_safe_create_on_dataload_complete_task()` scheduled the coroutine unconditionally, without the `_dataload_complete_fired` guard the regular completion paths already use.

## Home Assistant does not guard this

Checked against the HA source (2026.8.3, `config_entries.py:2788-2805`): `async_forward_entry_setups()` only serializes through `entry.setup_lock` when that lock is **not** already held, i.e. when called after setup has finished. This integration forwards from the websocket task while `async_setup_entry` is still in progress, so the lock *is* held and the call goes straight to `_async_forward_entry_setups_locked()` with no re-entrancy check — followed by the `_report_non_awaited_platform_forwards` warning that also shows up in the report. The `ValueError` itself comes from `helpers/entity_component.py:183`.

So the serialization has to live in the integration.

## Changes

**`coordinator.py`**
- Serialize `on_dataload_complete()` with an `asyncio.Lock` and set `entry_setup_complete` *inside* the lock, directly after the forward. If the forward fails the flag stays unset, so a later invocation can still retry.
- Drop the `@callback` decorator — it marks synchronous, loop-safe functions and does not belong on a coroutine function.

**`client.py`**
- Replace the fallback with `async_call_later()`, guarded by `_dataload_complete_fired` and cancelled once the regular path completes.
- This also removes the round trip `call_later` → `async_add_executor_job` → `run_coroutine_threadsafe`. The `call_later` callback already runs on the event loop, so the excursion into the thread pool was pure latency, and the returned future was never awaited — which swallowed exceptions and matches the "never retrieved" symptom seen in #323.

## Testing

Reproduced the race against a stub that mimics HA's duplicate-forward behaviour, with two invocations overlapping inside the forward:

```
old    forward calls=2  errors=['ValueError: Config entry entry has already been setup!']
new    forward calls=1  errors=none
```

`ruff format` and `ruff check` clean — the 6 remaining `PLR0917`/`BLE001` findings in `client.py` are pre-existing and unchanged.

## Compatibility

Minimum supported HA is 2024.02.0 (`hacs.json`). Everything used here predates that by years: `asyncio.Lock` (stdlib), `homeassistant.helpers.event.async_call_later`, `homeassistant.core.callback`, `hass.async_create_task`. No version gate needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)