### PR TITLE
feat: add binary sensors for the deck lid

### DIFF
--- a/custom_components/mbapi2020/const.py
+++ b/custom_components/mbapi2020/const.py
@@ -643,6 +643,38 @@ BinarySensors = {
         None,
         None,
     ],
+    "decklidstatus": [
+        "Deck lid",
+        None,  # Deprecated: DO NOT USE
+        "doors",
+        "decklidstatus",
+        "value",
+        None,
+        None,
+        None,
+        BinarySensorDeviceClass.OPENING,
+        False,
+        None,
+        None,
+        None,
+        None,
+    ],
+    "doorlockstatusdecklid": [
+        "Deck lid lock",
+        None,  # Deprecated: DO NOT USE
+        "doors",
+        "doorlockstatusdecklid",
+        "value",
+        None,
+        None,
+        None,
+        BinarySensorDeviceClass.LOCK,
+        False,
+        None,
+        None,
+        None,
+        None,
+    ],
     "chargeflapacstatus": [
         "Charge Flap AC Status",
         None,  # Deprecated: DO NOT USE

--- a/custom_components/mbapi2020/translations/cs.json
+++ b/custom_components/mbapi2020/translations/cs.json
@@ -560,6 +560,12 @@
     "binary_sensor": {
       "chargingactive": {
         "name": "Nabíjení aktivní"
+      },
+      "decklidstatus": {
+        "name": "Zavazadlový prostor"
+      },
+      "doorlockstatusdecklid": {
+        "name": "Zámek zavazadlového prostoru"
       }
     },
     "sensor": {

--- a/custom_components/mbapi2020/translations/da.json
+++ b/custom_components/mbapi2020/translations/da.json
@@ -560,6 +560,12 @@
     "binary_sensor": {
       "chargingactive": {
         "name": "Opladning aktiv"
+      },
+      "decklidstatus": {
+        "name": "Bagklap"
+      },
+      "doorlockstatusdecklid": {
+        "name": "Bagklaplås"
       }
     },
     "sensor": {

--- a/custom_components/mbapi2020/translations/de.json
+++ b/custom_components/mbapi2020/translations/de.json
@@ -560,6 +560,12 @@
     "binary_sensor": {
       "chargingactive": {
         "name": "Ladevorgang aktiv"
+      },
+      "decklidstatus": {
+        "name": "Kofferraumklappe"
+      },
+      "doorlockstatusdecklid": {
+        "name": "Kofferraumklappenschloss"
       }
     },
     "sensor": {

--- a/custom_components/mbapi2020/translations/en.json
+++ b/custom_components/mbapi2020/translations/en.json
@@ -560,6 +560,12 @@
     "binary_sensor": {
       "chargingactive": {
         "name": "Charging active"
+      },
+      "decklidstatus": {
+        "name": "Deck lid"
+      },
+      "doorlockstatusdecklid": {
+        "name": "Deck lid lock"
       }
     },
     "sensor": {

--- a/custom_components/mbapi2020/translations/es.json
+++ b/custom_components/mbapi2020/translations/es.json
@@ -560,6 +560,12 @@
     "binary_sensor": {
       "chargingactive": {
         "name": "Carga activa"
+      },
+      "decklidstatus": {
+        "name": "Tapa del maletero"
+      },
+      "doorlockstatusdecklid": {
+        "name": "Bloqueo de la tapa del maletero"
       }
     },
     "sensor": {

--- a/custom_components/mbapi2020/translations/fi.json
+++ b/custom_components/mbapi2020/translations/fi.json
@@ -560,6 +560,12 @@
     "binary_sensor": {
       "chargingactive": {
         "name": "Lataus aktiivinen"
+      },
+      "decklidstatus": {
+        "name": "Tavaratilan kansi"
+      },
+      "doorlockstatusdecklid": {
+        "name": "Tavaratilan kannen lukko"
       }
     },
     "sensor": {

--- a/custom_components/mbapi2020/translations/fr.json
+++ b/custom_components/mbapi2020/translations/fr.json
@@ -560,6 +560,12 @@
     "binary_sensor": {
       "chargingactive": {
         "name": "Charge en cours"
+      },
+      "decklidstatus": {
+        "name": "Couvercle de coffre"
+      },
+      "doorlockstatusdecklid": {
+        "name": "Serrure du couvercle de coffre"
       }
     },
     "sensor": {

--- a/custom_components/mbapi2020/translations/he.json
+++ b/custom_components/mbapi2020/translations/he.json
@@ -560,6 +560,12 @@
     "binary_sensor": {
       "chargingactive": {
         "name": "טעינה פעילה"
+      },
+      "decklidstatus": {
+        "name": "מכסה תא מטען"
+      },
+      "doorlockstatusdecklid": {
+        "name": "נעילת מכסה תא מטען"
       }
     },
     "sensor": {

--- a/custom_components/mbapi2020/translations/it.json
+++ b/custom_components/mbapi2020/translations/it.json
@@ -560,6 +560,12 @@
     "binary_sensor": {
       "chargingactive": {
         "name": "Ricarica attiva"
+      },
+      "decklidstatus": {
+        "name": "Cofano posteriore"
+      },
+      "doorlockstatusdecklid": {
+        "name": "Serratura cofano posteriore"
       }
     },
     "sensor": {

--- a/custom_components/mbapi2020/translations/nb_NO.json
+++ b/custom_components/mbapi2020/translations/nb_NO.json
@@ -560,6 +560,12 @@
     "binary_sensor": {
       "chargingactive": {
         "name": "Lading aktiv"
+      },
+      "decklidstatus": {
+        "name": "Bagasjelokk"
+      },
+      "doorlockstatusdecklid": {
+        "name": "Bagasjelokklås"
       }
     },
     "sensor": {

--- a/custom_components/mbapi2020/translations/nl.json
+++ b/custom_components/mbapi2020/translations/nl.json
@@ -560,6 +560,12 @@
     "binary_sensor": {
       "chargingactive": {
         "name": "Opladen actief"
+      },
+      "decklidstatus": {
+        "name": "Bagageklep"
+      },
+      "doorlockstatusdecklid": {
+        "name": "Bagageklepslot"
       }
     },
     "sensor": {

--- a/custom_components/mbapi2020/translations/pl.json
+++ b/custom_components/mbapi2020/translations/pl.json
@@ -560,6 +560,12 @@
     "binary_sensor": {
       "chargingactive": {
         "name": "Ładowanie aktywne"
+      },
+      "decklidstatus": {
+        "name": "Klapa bagażnika"
+      },
+      "doorlockstatusdecklid": {
+        "name": "Zamek klapy bagażnika"
       }
     },
     "sensor": {

--- a/custom_components/mbapi2020/translations/pt.json
+++ b/custom_components/mbapi2020/translations/pt.json
@@ -560,6 +560,12 @@
     "binary_sensor": {
       "chargingactive": {
         "name": "Carregamento ativo"
+      },
+      "decklidstatus": {
+        "name": "Tampa da mala"
+      },
+      "doorlockstatusdecklid": {
+        "name": "Fecho da tampa da mala"
       }
     },
     "sensor": {

--- a/custom_components/mbapi2020/translations/sv.json
+++ b/custom_components/mbapi2020/translations/sv.json
@@ -560,6 +560,12 @@
     "binary_sensor": {
       "chargingactive": {
         "name": "Laddning aktiv"
+      },
+      "decklidstatus": {
+        "name": "Bagagelucka"
+      },
+      "doorlockstatusdecklid": {
+        "name": "Bagageluckslås"
       }
     },
     "sensor": {

--- a/custom_components/mbapi2020/translations/ta.json
+++ b/custom_components/mbapi2020/translations/ta.json
@@ -560,6 +560,12 @@
     "binary_sensor": {
       "chargingactive": {
         "name": "சார்ஜிங் செயலில்"
+      },
+      "decklidstatus": {
+        "name": "டெக் மூடி"
+      },
+      "doorlockstatusdecklid": {
+        "name": "டெக் மூடி பூட்டு"
       }
     },
     "sensor": {

--- a/custom_components/mbapi2020/translations/uk.json
+++ b/custom_components/mbapi2020/translations/uk.json
@@ -560,6 +560,12 @@
     "binary_sensor": {
       "chargingactive": {
         "name": "Заряджання активне"
+      },
+      "decklidstatus": {
+        "name": "Кришка багажника"
+      },
+      "doorlockstatusdecklid": {
+        "name": "Замок кришки багажника"
       }
     },
     "sensor": {


### PR DESCRIPTION
The deck lid was only reachable as an extra state attribute on the lock sensor. This exposes it as two entities of its own.

## New entities

| Entity | Attribute | Device class | On means |
|---|---|---|---|
| Deck lid | `decklidstatus` | `opening` | open |
| Deck lid lock | `doorlockstatusdecklid` | `lock` | unlocked |

`binary_sensor.py` iterates `BinarySensors` on its own, so this is data only — no code change.

## Why no `flip`

Both proto enums happen to line up with Home Assistant's device class semantics exactly:

| Enum | Values | HA device class |
|---|---|---|
| `Doorstatus` | `0 CLOSED`, `1 OPEN` | `OPENING` — *"On means open"* |
| `Doorlockstatus` | `0 LOCKED`, `1 UNLOCKED` | `LOCK` — *"On means open (unlocked)"* |

`Doorlockstatus` is inverted against intuition (`0` = locked), but that is precisely HA's convention, so `FLIP_RESULT` stays `False`. Field types confirmed from the descriptor: `VehicleStatusUpdate.decklidstatus: DoorstatusEnumAttribute`, `VehicleStatusUpdate.doorlockstatusdecklid: DoorlockstatusEnumAttribute`.

## No capability check needed

Capability field stays `None`. Cars that do not report the attributes get `CarAttribute(0, 4, 0)` from the generic handler, and the eligibility check in `_create_binary_sensor_if_eligible` skips retrieval status 4. That is the natural gate.

One detail worth recording: proto3 omits default values, so a *closed* deck lid arrives with no `value` key at all. The generic handler falls back to `0` while keeping `status="VALID"`, so it correctly reads "closed" instead of going unavailable. Same on the VSU path — `_normalize_value` writes no key when the value is `None` and the rest is identical, so no `_VSU_DEFAULT_OMITTED_VALUES` entry is required.

## Translations

All 16 language files. The "Deck lid" name is reused verbatim from the `decklidstatus` attribute name each file already carries, so nothing is renamed or invented. The lock names follow the pattern each language already uses for the other door locks (e.g. de `Tankklappenschloss` → `Kofferraumklappenschloss`). Weblate contributors can refine the 15 non-English lock names.

## Compatibility

The attributes stay on the lock sensor too, so existing templates keep working.

## Testing

Exercised the real `is_on` chain from `binary_sensor.py` against both enum values, the proto3-omitted-default case, the VSU enum string path, and the actual diagnostics attached to #426:

```
decklidstatus          value=0 status=VALID -> is_on=False -> closed
doorlockstatusdecklid  value=0 status=VALID -> is_on=False -> locked
```

`ruff format` and `ruff check` clean, all 16 JSON files parse, and the translation diffs are purely additive (6 lines each, no reformatting).

🤖 Generated with [Claude Code](https://claude.com/claude-code)