### PR TITLE
fix: restore window position for the intermediate airing status

### DIFF
--- a/custom_components/mbapi2020/cover.py
+++ b/custom_components/mbapi2020/cover.py
@@ -26,12 +26,17 @@ from .coordinator import MBAPI2020DataUpdateCoordinator
 from .helper import LogHelper as loghelper
 
 # Positions for the individual windows, based on the proto enum Windowstatus:
-# 0 INTERMEDIATE, 1 COMPLETELY_OPENED, 2 COMPLETELY_CLOSED, 3 AIRING_POSITION
-WINDOW_STATUS_POSITIONS: dict[int, int] = {0: 50, 1: 100, 2: 0, 3: 10}
+# 0 INTERMEDIATE, 1 COMPLETELY_OPENED, 2 COMPLETELY_CLOSED, 3 AIRING_POSITION,
+# 4 INTERMEDIATE_AIRING_POSITION, 5 RUNNING
+# RUNNING is deliberately absent: it means the window is moving and carries no
+# direction, so any position would be a guess. The entity reports unknown until
+# the car sends the status it settled on.
+WINDOW_STATUS_POSITIONS: dict[int, int] = {0: 50, 1: 100, 2: 0, 3: 10, 4: 50}
 
 # Positions for the window summary, based on the proto enum WindowStatusOverall:
-# 0 OPEN, 1 CLOSED, 2 COMPLETELY_OPEN, 3 AIRING
-# Note the numbering differs from the individual windows above
+# 0 OPEN, 1 CLOSED, 2 COMPLETELY_OPEN, 3 AIRING, 4 RUNNING
+# Note the numbering differs from the individual windows above, and RUNNING is
+# absent here for the same reason
 WINDOW_STATUS_OVERALL_POSITIONS: dict[int, int] = {0: 50, 1: 0, 2: 100, 3: 10}
 
 # Retrieval status values that indicate the car did not report a usable value


### PR DESCRIPTION
Found while comparing the Mercedes Android app 1.71 against the proto sources.

## Problem

The `Windowstatus` enum has six values, not four:

| value | name | position |
|---|---|---|
| 0 | INTERMEDIATE | 50 |
| 1 | COMPLETELY_OPENED | 100 |
| 2 | COMPLETELY_CLOSED | 0 |
| 3 | AIRING_POSITION | 10 |
| 4 | INTERMEDIATE_AIRING_POSITION | 50 |
| 5 | RUNNING | — |

`WindowStatusOverall` likewise has a fifth value, `4 RUNNING`. Both were missing from the position maps.

Value 4 used to map to position 50 through the old `WINDOW_STATUS_INTERMEDIATE = {"0", 0, "4", 4}` set. The rewrite in #427 replaced that with an explicit enum map that only covered 0 to 3, so a window sitting in the intermediate airing position reported no position at all. That was my regression — the original code knew about the value and I dropped it while tidying up.

## Changes

- Restore `4 → 50` for the individual windows, matching the behaviour before #427.
- Document that `RUNNING` is deliberately unmapped in both enums: it means the window is moving and carries no direction, so any position would be a guess. The entity reports unknown until the car sends the status it settled on. This was already the effective behaviour, but only as an accident of a missing dict key — now it is stated.

## Evidence — these values occur constantly

Enum ranges taken from the decompiled app 1.71, cross-checked against the proto sources. Counted across 122302 recorded websocket dumps:

| field | value 4 | value 5 |
|---|---|---|
| `windowstatusfrontleft` | 355 | 493 |
| `windowstatusfrontright` | 210 | 210 |
| `windowstatusrearleft` | 120 | 114 |
| `windowstatusrearright` | 173 | 169 |
| `window_status_overall` | 957 (RUNNING) | — |

Confirmed independently by decoding 4000 of the raw binary dumps and reading `field.value`, which yields the wire integer regardless of how the proto names it.

> A first pass at this evidence was wrong and said the values never occur. It grepped the JSON dumps for enum *strings*. Those dumps are written through the integration's own proto, so a value the proto does not know is serialised as a bare number (`"value": 4`), never as a string — the search was structurally blind to exactly the case it was meant to detect.

## Testing

Exercised the real `_status_to_position` against all six enum values, comparing three generations of the code:

```
  wert name                            vor #427   #427  jetzt
  0    INTERMEDIATE                          50     50     50
  1    COMPLETELY_OPENED                    100    100    100
  2    COMPLETELY_CLOSED                      0      0      0
  3    AIRING_POSITION                       10     10     10
  4    INTERMEDIATE_AIRING_POSITION          50   None     50  <- Regression behoben
  5    RUNNING                             None   None   None  (unverändert unbekannt)
```

Plus the summary enum (`4 RUNNING → None`) and the edge cases (`"4"` → 50, `None`, bool, garbage). `ruff format` and `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)