### PR TITLE
Fix battery_max_soc_configure rejecting cars with only CHARGE_PROGRAM…

### DIFF
--- a/custom_components/mbapi2020/client.py
+++ b/custom_components/mbapi2020/client.py
@@ -1667,8 +1667,10 @@ class Client:
             charge_program,
         )
 
-        if not self._is_car_feature_available(vin, "BATTERY_MAX_SOC_CONFIGURE") and not self._is_car_feature_available(
-            vin, "CHARGING_CONFIGURE"
+        if (
+            not self._is_car_feature_available(vin, "BATTERY_MAX_SOC_CONFIGURE")
+            and not self._is_car_feature_available(vin, "CHARGING_CONFIGURE")
+            and not self._is_car_feature_available(vin, "CHARGE_PROGRAM_CONFIGURE")
         ):
             LOGGER.warning(
                 "Can't configure battery_max_soc for car %s. Features BATTERY_MAX_SOC_CONFIGURE or CHARGING_CONFIGURE not availabe for this car.",


### PR DESCRIPTION
WHAT
    Adds CHARGE_PROGRAM_CONFIGURE to the capability guard in
    battery_max_soc_configure().

WHY
    The guard only accepts BATTERY_MAX_SOC_CONFIGURE or CHARGING_CONFIGURE.
    On a 2023 GLC 400e both are unavailable:

        BATTERY_MAX_SOC_CONFIGURE  isAvailable: false  SERVICE_NOT_AVAILABLE
        CHARGING_CONFIGURE         isAvailable: false  NOT_SUPPORTED_BY_VEHICLE

    but CHARGE_PROGRAM_CONFIGURE is available and carries MAX_SOC as a
    parameter (minValue 50, maxValue 100, steps 10). That is how the phone app
    sets the charge target on this car.

    So the service refused with "Features BATTERY_MAX_SOC_CONFIGURE or
    CHARGING_CONFIGURE not availabe for this car" even though the branch it
    would then have taken - the existing ChargeProgramConfigure one - works.
    __init__.py already detects this case and sets the CHARGE_PROGRAM_CONFIGURE
    feature from the MAX_SOC parameter; the guard just never consulted it.

    After the fix the service sends CHARGEPROGRAMCONFIGURE and the target is
    updated on the car. Confirmed working on the GLC 400e.

    This only widens the guard. The branch selection below it is untouched, so
    there is no behaviour change for vehicles that do report
    BATTERY_MAX_SOC_CONFIGURE or CHARGING_CONFIGURE.
